### PR TITLE
fix balance command, now returning all balances when no arguments

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -88,7 +88,11 @@ pub async fn get_balance_command(ctx: &Context, msg: &Message) -> anyhow::Result
 			result.push_str(&format!("`{} {:.02}`\n", info.code, real_balance));
 		}
 
-		result.into()
+		if result.is_empty() {
+			"`KSN 0.00`".into()
+		} else {
+			result.into()
+		}
 	};
 
 	msg.channel_id


### PR DESCRIPTION
- `!balance` -- will print all balances that are not zero
- `!balance <currency 1> ... <currency n>` will print only the specified ones